### PR TITLE
CGT-2989: Fixed unknow tax year bug

### DIFF
--- a/test/controllers/CalculationControllerTests/AnnualExemptAmountActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/AnnualExemptAmountActionSpec.scala
@@ -81,6 +81,9 @@ class AnnualExemptAmountActionSpec extends UnitSpec with WithFakeApplication wit
     when(mockCalcConnector.getPartialAEA(ArgumentMatchers.anyInt())(ArgumentMatchers.any()))
       .thenReturn(Some(BigDecimal(5550)))
 
+    when(mockCalcConnector.getTaxYear(ArgumentMatchers.anyString())(ArgumentMatchers.any()))
+      .thenReturn(Some(TaxYearModel("2016-5-6", isValidYear = true, "2016/17")))
+
     new AnnualExemptAmountController {
       override val calcConnector: CalculatorConnector = mockCalcConnector
     }

--- a/test/controllers/CalculationControllerTests/PersonalAllowanceActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/PersonalAllowanceActionSpec.scala
@@ -31,7 +31,7 @@ import org.scalatest.mock.MockitoSugar
 
 import scala.concurrent.Future
 import controllers.routes
-import models.{DisposalDateModel, PersonalAllowanceModel}
+import models.{DisposalDateModel, PersonalAllowanceModel, TaxYearModel}
 
 class PersonalAllowanceActionSpec extends UnitSpec with WithFakeApplication with MockitoSugar with FakeRequestHelper {
 
@@ -48,6 +48,9 @@ class PersonalAllowanceActionSpec extends UnitSpec with WithFakeApplication with
     when(mockCalcConnector.fetchAndGetFormData[DisposalDateModel](
       ArgumentMatchers.eq(KeystoreKeys.disposalDate))(ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(Future.successful(Some(DisposalDateModel(6, 5, 2016))))
+
+    when(mockCalcConnector.getTaxYear(ArgumentMatchers.anyString())(ArgumentMatchers.any()))
+      .thenReturn(Some(TaxYearModel("2016-5-6", isValidYear = true, "2016/17")))
 
     when(mockCalcConnector.getPA(ArgumentMatchers.anyInt(), ArgumentMatchers.anyBoolean())(ArgumentMatchers.any()))
       .thenReturn(Some(BigDecimal(11000)))


### PR DESCRIPTION
Updated the code to pass the tax year of the closest know tax year to the disposal date. Therefore passing
in a future date would use the AEA or personal allowance for the latest tax year.