### PR TITLE
DL-2163 - Updated dependencies to pull in updated version of simple r…

### DIFF
--- a/project/frontendBuild.scala
+++ b/project/frontendBuild.scala
@@ -37,14 +37,14 @@ private object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "0.37.0",
-    "uk.gov.hmrc" %% "play-partials" % "6.5.0",
-    "uk.gov.hmrc" %% "http-caching-client" % "8.1.0",
-    "uk.gov.hmrc" %% "mongo-caching" % "6.1.0-play-26",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "0.44.0",
+    "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-26",
+    "uk.gov.hmrc" %% "http-caching-client" % "8.4.0-play-26",
+    "uk.gov.hmrc" %% "mongo-caching" % "6.6.0-play-26",
     "uk.gov.hmrc" %% "play-language" % "3.4.0",
     "it.innove"   % "play2-pdf" % "1.5.1",
-    "uk.gov.hmrc" %% "govuk-template" % "5.30.0-play-26",
-    "uk.gov.hmrc" %% "play-ui" % "7.33.0-play-26",
+    "uk.gov.hmrc" %% "govuk-template" % "5.37.0-play-26",
+    "uk.gov.hmrc" %% "play-ui" % "7.40.0-play-26",
     "com.typesafe.play" %% "play-java" % "2.6.12",
     nettyServer
   )
@@ -57,7 +57,7 @@ private object AppDependencies {
   object Test {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % "3.6.0-play-26" % scope,
+        "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-26" % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % scope,
         "org.mockito" % "mockito-core" % "2.13.0" % scope,
         "org.pegdown" % "pegdown" % "1.6.0" % scope,


### PR DESCRIPTION
…eactive mongo

# DL-2163-  Update simple-reactive mongo dependencies

This service doesn't use Mongo or have a direct simple-reactive mongo reference defined.
A reference is pulled in via common dependencies though.
Updated the dependencies to bring in the later reactive-mongo sub dependency

## Checklist

 - [x ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x ]  I've run a dependency check to ensure all dependencies are up to date