### PR TITLE
DL-2830 - disabled JUnitXmlReportPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val scoverageSettings = {
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins : _*)
+  .disablePlugins(JUnitXmlReportPlugin)
   .settings(scoverageSettings : _*)
   .settings(majorVersion := 1)
   .settings(playSettings : _*)


### PR DESCRIPTION
# DL-2830 - disabled JUnitXmlReportPlugin

Disabled `JUnitXmlReportPlugin` which was preventing this service from building successfully on Jenkins.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
