### PR TITLE
DL-3735 Updating dependencies & removing warnings

### DIFF
--- a/app/connectors/CalculatorConnector.scala
+++ b/app/connectors/CalculatorConnector.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.http.cache.client.{CacheMap, SessionCache}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
+import uk.gov.hmrc.http.HttpReads.Implicits._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/app/controllers/PrivateResidenceReliefController.scala
+++ b/app/controllers/PrivateResidenceReliefController.scala
@@ -19,7 +19,6 @@ package controllers
 import java.time.LocalDate
 
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
-import common.TaxDates.PrivateResidenceReliefDateDetails
 import common.nonresident.TaxableGainCalculation.{checkGainExists, getPropertyLivedInResponse}
 import common.{Dates, TaxDates}
 import config.ApplicationConfig

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,14 +22,14 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.8.0",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.13.0",
     "uk.gov.hmrc" %% "play-partials" % "6.11.0-play-26",
-    "uk.gov.hmrc" %% "http-caching-client" % "9.0.0-play-26",
-    "uk.gov.hmrc" %% "mongo-caching" % "6.12.0-play-26",
-    "uk.gov.hmrc" %% "play-language" % "4.2.0-play-26",
+    "uk.gov.hmrc" %% "http-caching-client" % "9.1.0-play-26",
+    "uk.gov.hmrc" %% "mongo-caching" % "6.15.0-play-26",
+    "uk.gov.hmrc" %% "play-language" % "4.3.0-play-26",
     "it.innove"   % "play2-pdf" % "1.8.2" exclude("com.typesafe.play","*"),
     "uk.gov.hmrc" %% "govuk-template" % "5.55.0-play-26",
-    "uk.gov.hmrc" %% "play-ui" % "8.10.0-play-26",
+    "uk.gov.hmrc" %% "play-ui" % "8.11.0-play-26",
     nettyServer
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
 resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.7.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 


### PR DESCRIPTION
DL-3735

Updating dependencies. Simple-reactivemongo upgrade should be pulled implicitly by mongo-caching, which has been updated to the most recent version

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
