### PR TITLE
DL-12067 fixed unintended BigDecimal behaviour

### DIFF
--- a/app/common/Transformers.scala
+++ b/app/common/Transformers.scala
@@ -38,22 +38,18 @@ object Transformers {
   }
 
   val optionalBigDecimalToOptionalString: Option[BigDecimal] => Option[String] = {
-    case Some(data) => Some(data.toString())
+    case Some(data) => Some(bigDecimalToString(data))
     case None => None
   }
 
   val bigDecimalToString: BigDecimal => String = (input) => input.scale match {
-    case 1 => input.setScale(2).toString()
+    case scale if scale < 2 && scale != 0 => input.setScale(2).toString()
     case _ => input.toString
   }
 
-  val optionalBigDecimalToString: Option[BigDecimal] => String = (input) =>
-    if (input.isEmpty) ""
-    else {
-    input.get.scale match {
-      case 1 => input.getOrElse(BigDecimal(0.0)).setScale(2).toString()
-      case _ => input.getOrElse(BigDecimal(0.0)).toString
-    }
+  val optionalBigDecimalToString: Option[BigDecimal] => String = {
+    case Some(data) => bigDecimalToString(data)
+    case None => ""
   }
 
   val stringToInteger: String => Int = (input) => Try(input.trim.toInt) match {

--- a/app/connectors/CalculatorConnector.scala
+++ b/app/connectors/CalculatorConnector.scala
@@ -91,7 +91,7 @@ class CalculatorConnector @Inject()(val http: DefaultHttpClient,
         model.costs.get
       case (Some(model), _) if !TaxDates.dateBeforeLegislationStart(answers.acquisitionDateModel.get) =>
         model.acquisitionCostsAmt
-      case _ => 0
+      case _ => BigDecimal(0)
     }
   }
 
@@ -99,13 +99,13 @@ class CalculatorConnector @Inject()(val http: DefaultHttpClient,
     case Some(calculationElection) =>
       if(calculationElection.calculationType == CalculationType.rebased) {
         http.GET[BigDecimal](s"$serviceUrl/capital-gains-calculator/non-resident/calculate-total-costs?" +
-          s"disposalCosts=${answers.disposalCostsModel.disposalCosts}" +
-          s"&acquisitionCosts=${answers.rebasedCostsModel.get.rebasedCosts.getOrElse(0)}" +
-          improvementsQueryParameter(answers.improvementsModel, answers.improvementsModel.improvementsAmtAfter.getOrElse(0)))
+          s"disposalCosts=${answers.disposalCostsModel.disposalCosts.toDouble}" +
+          s"&acquisitionCosts=${answers.rebasedCostsModel.get.rebasedCosts.getOrElse(BigDecimal(0)).toDouble}" +
+          improvementsQueryParameter(answers.improvementsModel, answers.improvementsModel.improvementsAmtAfter.getOrElse(BigDecimal(0)).toDouble))
       } else {
         http.GET[BigDecimal](s"$serviceUrl/capital-gains-calculator/non-resident/calculate-total-costs?" +
-          s"disposalCosts=${answers.disposalCostsModel.disposalCosts}" +
-          s"&acquisitionCosts=${selectAcquisitionCosts(answers)}" +
+          s"disposalCosts=${answers.disposalCostsModel.disposalCosts.toDouble}" +
+          s"&acquisitionCosts=${selectAcquisitionCosts(answers).toDouble}" +
           improvementsQueryParameter(answers.improvementsModel,
             answers.improvementsModel.improvementsAmt.getOrElse(BigDecimal(0)) + answers.improvementsModel.improvementsAmtAfter.getOrElse(BigDecimal(0))))
       }
@@ -113,7 +113,7 @@ class CalculatorConnector @Inject()(val http: DefaultHttpClient,
   }
 
   private def improvementsQueryParameter(improvementsModel: ImprovementsModel, value: BigDecimal): String = {
-    if(improvementsModel.isClaimingImprovements == YesNoKeys.yes) s"&improvements=$value"
+    if(improvementsModel.isClaimingImprovements == YesNoKeys.yes) s"&improvements=${value.toDouble}"
     else "&improvements=0"
   }
 

--- a/app/constructors/FinalTaxAnswersRequestConstructor.scala
+++ b/app/constructors/FinalTaxAnswersRequestConstructor.scala
@@ -37,14 +37,14 @@ object FinalTaxAnswersRequestConstructor {
 
   def currentIncome(currentIncomeModel: Option[CurrentIncomeModel]): String = {
     currentIncomeModel match {
-      case Some(data) => s"&currentIncome=${data.currentIncome}"
+      case Some(data) => s"&currentIncome=${data.currentIncome.toDouble}"
       case _ => ""
     }
   }
 
   def personalAllowanceAmt(personalAllowanceModel: Option[PersonalAllowanceModel]): String =
     personalAllowanceModel match {
-      case Some(data) => s"&personalAllowanceAmt=${data.personalAllowanceAmt}"
+      case Some(data) => s"&personalAllowanceAmt=${data.personalAllowanceAmt.toDouble}"
       case _ => ""
     }
 
@@ -53,7 +53,7 @@ object FinalTaxAnswersRequestConstructor {
                     howMuchLossModel: Option[HowMuchLossModel]): String = {
     (otherPropertiesModel, previousLossOrGainModel) match {
       case (Some(OtherPropertiesModel(YesNoKeys.yes)), Some(PreviousLossOrGainModel(PreviousGainOrLossKeys.loss))) =>
-        s"&allowableLoss=${howMuchLossModel.get.loss}"
+        s"&allowableLoss=${howMuchLossModel.get.loss.toDouble}"
       case _ => ""
     }
   }
@@ -63,7 +63,7 @@ object FinalTaxAnswersRequestConstructor {
                    howMuchGainModel: Option[HowMuchGainModel]): String = {
     (otherPropertiesModel, previousLossOrGainModel) match {
       case (Some(OtherPropertiesModel(YesNoKeys.yes)),Some(PreviousLossOrGainModel(PreviousGainOrLossKeys.gain))) =>
-        s"&previousGain=${howMuchGainModel.get.howMuchGain}"
+        s"&previousGain=${howMuchGainModel.get.howMuchGain.toDouble}"
       case _ => ""
     }
   }
@@ -78,21 +78,21 @@ object FinalTaxAnswersRequestConstructor {
     (otherPropertiesModel, previousLossOrGainModel, howMuchLossModel, howMuchGainModel) match {
 
       case (Some(OtherPropertiesModel(YesNoKeys.yes)), Some(PreviousLossOrGainModel(PreviousGainOrLossKeys.loss)),
-      Some(HowMuchLossModel(loss)), _) if loss == 0.0 => s"&annualExemptAmount=${annualExemptAmountModel.get.annualExemptAmount}"
+      Some(HowMuchLossModel(loss)), _) if loss == 0.0 => s"&annualExemptAmount=${annualExemptAmountModel.get.annualExemptAmount.toDouble}"
       case (Some(OtherPropertiesModel(YesNoKeys.yes)), Some(PreviousLossOrGainModel(PreviousGainOrLossKeys.gain)), _,
-      Some(HowMuchGainModel(gain))) if gain == 0.0 => s"&annualExemptAmount=${annualExemptAmountModel.get.annualExemptAmount}"
+      Some(HowMuchGainModel(gain))) if gain == 0.0 => s"&annualExemptAmount=${annualExemptAmountModel.get.annualExemptAmount.toDouble}"
       case (Some(OtherPropertiesModel(YesNoKeys.yes)), Some(PreviousLossOrGainModel(PreviousGainOrLossKeys.gain)), _,
       Some(HowMuchGainModel(_))) => "&annualExemptAmount=0"
       case (Some(OtherPropertiesModel(YesNoKeys.yes)), Some(PreviousLossOrGainModel(PreviousGainOrLossKeys.neither)), _, _) =>
-        s"&annualExemptAmount=${annualExemptAmountModel.get.annualExemptAmount}"
+        s"&annualExemptAmount=${annualExemptAmountModel.get.annualExemptAmount.toDouble}"
       case (_, _, _, _) =>
-        s"&annualExemptAmount=$maxAnnualExemptAmount"
+        s"&annualExemptAmount=${maxAnnualExemptAmount.toDouble}"
     }
   }
 
   def broughtForwardLosses(model: Option[BroughtForwardLossesModel]): String = {
     if (model.isDefined && model.get.isClaiming) {
-      s"&broughtForwardLoss=${model.get.broughtForwardLoss.get}"
+      s"&broughtForwardLoss=${model.get.broughtForwardLoss.get.toDouble}"
     } else {
       ""
     }

--- a/app/constructors/OtherReliefsRequestConstructor.scala
+++ b/app/constructors/OtherReliefsRequestConstructor.scala
@@ -27,17 +27,17 @@ object OtherReliefsRequestConstructor {
   }
 
   def flatReliefsQuery(reliefs: Option[OtherReliefsModel]): String = reliefs match {
-    case Some(data) => s"&otherReliefsFlat=${data.otherReliefs}"
+    case Some(data) => s"&otherReliefsFlat=${data.otherReliefs.toDouble}"
     case _ => ""
   }
 
   def rebasedReliefsQuery(reliefs: Option[OtherReliefsModel]): String = reliefs match {
-    case Some(data) => s"&otherReliefsRebased=${data.otherReliefs}"
+    case Some(data) => s"&otherReliefsRebased=${data.otherReliefs.toDouble}"
     case _ => ""
   }
 
   def timeApportionedReliefsQuery(reliefs: Option[OtherReliefsModel]): String = reliefs match {
-    case Some(data) => s"&otherReliefsTimeApportioned=${data.otherReliefs}"
+    case Some(data) => s"&otherReliefsTimeApportioned=${data.otherReliefs.toDouble}"
     case _ => ""
   }
 }

--- a/app/constructors/TotalGainRequestConstructor.scala
+++ b/app/constructors/TotalGainRequestConstructor.scala
@@ -35,15 +35,15 @@ object TotalGainRequestConstructor {
   }
 
   def disposalValue(disposalValueModel: DisposalValueModel): String = {
-    s"disposalValue=${disposalValueModel.disposalValue}"
+    s"disposalValue=${disposalValueModel.disposalValue.toDouble}"
   }
 
   def disposalCosts(disposalCostsModel: DisposalCostsModel): String = {
-    s"&disposalCosts=${disposalCostsModel.disposalCosts}"
+    s"&disposalCosts=${disposalCostsModel.disposalCosts.toDouble}"
   }
 
   def acquisitionValue(acquisitionValueModel: AcquisitionValueModel): String = {
-    s"&acquisitionValue=${acquisitionValueModel.acquisitionValueAmt}"
+    s"&acquisitionValue=${acquisitionValueModel.acquisitionValueAmt.toDouble}"
   }
 
   def acquisitionCosts(acquisitionCostsModel: Option[AcquisitionCostsModel],
@@ -56,11 +56,11 @@ object TotalGainRequestConstructor {
           model.costs.get
         case (Some(model), _) if !TaxDates.dateBeforeLegislationStart(acquisitionDateModel.get) =>
           model.acquisitionCostsAmt
-        case _ => 0
+        case _ => BigDecimal(0)
       }
     }
 
-    s"&acquisitionCosts=$selectAcquisitionCosts"
+    s"&acquisitionCosts=${selectAcquisitionCosts.toDouble}"
   }
 
   def includeLegislationCosts(costsAtLegislationStartModel: CostsAtLegislationStartModel, acquisitionDateModel: DateModel): Boolean = {
@@ -75,7 +75,7 @@ object TotalGainRequestConstructor {
   def improvements(improvementsModel: ImprovementsModel): String = {
     improvementsModel match {
       case ImprovementsModel("Yes", Some(value), _) =>
-        s"&improvements=$value"
+        s"&improvements=${value.toDouble}"
       case _ => ""
     }
   }
@@ -87,21 +87,21 @@ object TotalGainRequestConstructor {
     rebasedValueModel match {
       case Some(RebasedValueModel(value))
         if !TaxDates.dateAfterStart(acquisitionDateModel.get) =>
-        s"&rebasedValue=$value${rebasedCosts(rebasedCostsModel.get)}${improvementsAfterTaxStarted(improvementsModel)}"
+        s"&rebasedValue=${value.toDouble}${rebasedCosts(rebasedCostsModel.get)}${improvementsAfterTaxStarted(improvementsModel)}"
       case _ => ""
     }
   }
 
   def rebasedCosts(rebasedCostsModel: RebasedCostsModel): String = {
     rebasedCostsModel match {
-      case RebasedCostsModel("Yes", Some(value)) => s"&rebasedCosts=$value"
+      case RebasedCostsModel("Yes", Some(value)) => s"&rebasedCosts=${value.toDouble}"
       case _ => ""
     }
   }
 
   def improvementsAfterTaxStarted(improvementsModel: ImprovementsModel): String = {
     improvementsModel match {
-      case ImprovementsModel("Yes", _, Some(value)) => s"&improvementsAfterTaxStarted=$value"
+      case ImprovementsModel("Yes", _, Some(value)) => s"&improvementsAfterTaxStarted=${value.toDouble}"
       case _ => ""
     }
   }

--- a/test/constructors/FinalTaxAnswersRequestConstructorSpec.scala
+++ b/test/constructors/FinalTaxAnswersRequestConstructorSpec.scala
@@ -24,7 +24,7 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
   "Calling .currentIncome" should {
     "produce a valid query string for current income" in {
       FinalTaxAnswersRequestConstructor.currentIncome(Some(CurrentIncomeModel(10000))) shouldEqual
-      "&currentIncome=10000"
+      "&currentIncome=10000.0"
     }
 
     "produce an empty query string for current income if not provided" in {
@@ -35,7 +35,7 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
   "Calling .personalAllowanceAmt" should {
     "produce a valid query string when a personal allowance is supplied" in {
       FinalTaxAnswersRequestConstructor.personalAllowanceAmt(Some(PersonalAllowanceModel(10000))) shouldEqual
-      "&personalAllowanceAmt=10000"
+      "&personalAllowanceAmt=10000.0"
     }
 
     "produce a blank query string when no personal allowance is present is anything else" in {
@@ -48,7 +48,7 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
       FinalTaxAnswersRequestConstructor.allowableLoss(
         Some(OtherPropertiesModel("Yes")),
         Some(PreviousLossOrGainModel("Loss")),
-        Some(HowMuchLossModel(100))) shouldEqual "&allowableLoss=100"
+        Some(HowMuchLossModel(100))) shouldEqual "&allowableLoss=100.0"
     }
 
     "produce a blank query string when the user claims other properties and that was a gain" in {
@@ -75,7 +75,7 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
       FinalTaxAnswersRequestConstructor.previousGain(
         Some(OtherPropertiesModel("Yes")),
         Some(PreviousLossOrGainModel("Gain")),
-        Some(HowMuchGainModel(100))) shouldEqual "&previousGain=100"
+        Some(HowMuchGainModel(100))) shouldEqual "&previousGain=100.0"
     }
 
     "produce a blank query string when the user claims other properties and that was a loss" in {
@@ -107,7 +107,7 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
         None,
         Some(AnnualExemptAmountModel(2000)),
         1000.0
-      ) shouldEqual "&annualExemptAmount=2000"
+      ) shouldEqual "&annualExemptAmount=2000.0"
     }
 
     "produce the entered amount for aea if otherProperties = Yes, previousLossOrGain = Gain, howMuchGain == 0.0" in {
@@ -118,7 +118,7 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
         Some(HowMuchGainModel(0.0)),
         Some(AnnualExemptAmountModel(2000)),
         1000.0
-      ) shouldEqual "&annualExemptAmount=2000"
+      ) shouldEqual "&annualExemptAmount=2000.0"
     }
 
     "produce the entered amount for aea if otherProperties = Yes, previousLossOrGain = Gain, howMuchGain == 10000.0" in {
@@ -140,7 +140,7 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
         None,
         Some(AnnualExemptAmountModel(2000)),
         1000.0
-      ) shouldEqual "&annualExemptAmount=2000"
+      ) shouldEqual "&annualExemptAmount=2000.0"
     }
 
     "otherwise produce the maximum annual exempt amount supplied" in {
@@ -151,11 +151,12 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
         None,
         Some(AnnualExemptAmountModel(2000)),
         1000
-      ) shouldEqual "&annualExemptAmount=1000"
+      ) shouldEqual "&annualExemptAmount=1000.0"
     }
 
     "produce the maximum AEA value if no data is provided" in {
-      FinalTaxAnswersRequestConstructor.annualExemptAmount(None, None, None, None, None, 1000) shouldEqual "&annualExemptAmount=1000"
+      FinalTaxAnswersRequestConstructor.annualExemptAmount(None, None, None, None, None, 1000) shouldEqual
+        "&annualExemptAmount=1000.0"
     }
   }
 
@@ -163,7 +164,7 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
 
     "produce a valid query string when claiming" in {
       FinalTaxAnswersRequestConstructor.broughtForwardLosses(Some(BroughtForwardLossesModel(isClaiming = true,
-        Some(10000)))) shouldEqual "&broughtForwardLoss=10000"
+        Some(10000)))) shouldEqual "&broughtForwardLoss=10000.0"
     }
 
     "produce a blank query string when not claiming" in {
@@ -178,7 +179,8 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
   "Calling .additionalParametersQuery" should {
     "Return a String only containing the annualExemptAmount" when {
       "No TotalPersonalDetailsCalculationModel is passed" in {
-        FinalTaxAnswersRequestConstructor.additionalParametersQuery(None, BigDecimal(100)) shouldBe "&annualExemptAmount=100"
+        FinalTaxAnswersRequestConstructor.additionalParametersQuery(None, BigDecimal(100)) shouldBe
+          "&annualExemptAmount=100.0"
       }
     }
 
@@ -193,7 +195,8 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
           annualExemptAmountModel = None,
           broughtForwardLossesModel = BroughtForwardLossesModel(false, None))
 
-        FinalTaxAnswersRequestConstructor.additionalParametersQuery(Some(model), BigDecimal(100)) shouldBe "&currentIncome=100&annualExemptAmount=100"
+        FinalTaxAnswersRequestConstructor.additionalParametersQuery(Some(model), BigDecimal(100)) shouldBe
+          "&currentIncome=100.0&annualExemptAmount=100.0"
       }
     }
 
@@ -208,7 +211,8 @@ class FinalTaxAnswersRequestConstructorSpec extends CommonPlaySpec {
           annualExemptAmountModel = Some(AnnualExemptAmountModel(BigDecimal(500))),
           broughtForwardLossesModel = BroughtForwardLossesModel(false, None))
 
-        FinalTaxAnswersRequestConstructor.additionalParametersQuery(Some(model), model.annualExemptAmountModel.get.annualExemptAmount) shouldBe "&currentIncome=100&personalAllowanceAmt=200&annualExemptAmount=500"
+        FinalTaxAnswersRequestConstructor.additionalParametersQuery(Some(model), model.annualExemptAmountModel.get.annualExemptAmount) shouldBe
+          "&currentIncome=100.0&personalAllowanceAmt=200.0&annualExemptAmount=500.0"
       }
     }
 

--- a/test/constructors/OtherReliefsRequestConstructorSpec.scala
+++ b/test/constructors/OtherReliefsRequestConstructorSpec.scala
@@ -45,7 +45,7 @@ class OtherReliefsRequestConstructorSpec extends CommonPlaySpec {
     }
 
     "when called with some data" in {
-      OtherReliefsRequestConstructor.flatReliefsQuery(allReliefs.otherReliefsFlat) shouldEqual "&otherReliefsFlat=1"
+      OtherReliefsRequestConstructor.flatReliefsQuery(allReliefs.otherReliefsFlat) shouldEqual "&otherReliefsFlat=1.0"
     }
   }
 
@@ -56,7 +56,7 @@ class OtherReliefsRequestConstructorSpec extends CommonPlaySpec {
     }
 
     "when called with some data" in {
-      OtherReliefsRequestConstructor.rebasedReliefsQuery(allReliefs.otherReliefsRebased) shouldEqual "&otherReliefsRebased=2"
+      OtherReliefsRequestConstructor.rebasedReliefsQuery(allReliefs.otherReliefsRebased) shouldEqual "&otherReliefsRebased=2.0"
     }
   }
 
@@ -67,7 +67,7 @@ class OtherReliefsRequestConstructorSpec extends CommonPlaySpec {
     }
 
     "when called with some data" in {
-      OtherReliefsRequestConstructor.timeApportionedReliefsQuery(allReliefs.otherReliefsTime) shouldEqual "&otherReliefsTimeApportioned=3"
+      OtherReliefsRequestConstructor.timeApportionedReliefsQuery(allReliefs.otherReliefsTime) shouldEqual "&otherReliefsTimeApportioned=3.0"
     }
   }
 }

--- a/test/constructors/TotalGainRequestConstructorSpec.scala
+++ b/test/constructors/TotalGainRequestConstructorSpec.scala
@@ -26,7 +26,7 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
     "produce a valid query string" in {
       val result = TotalGainRequestConstructor.disposalValue(DisposalValueModel(1000))
 
-      result shouldBe "disposalValue=1000"
+      result shouldBe "disposalValue=1000.0"
     }
   }
 
@@ -35,7 +35,7 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
     "produce a valid query string" in {
       val result = TotalGainRequestConstructor.disposalCosts(DisposalCostsModel(100))
 
-      result shouldBe "&disposalCosts=100"
+      result shouldBe "&disposalCosts=100.0"
     }
   }
 
@@ -44,7 +44,7 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
     "produce a valid query string" in {
       val result = TotalGainRequestConstructor.acquisitionValue(AcquisitionValueModel(2000))
 
-      result shouldBe "&acquisitionValue=2000"
+      result shouldBe "&acquisitionValue=2000.0"
     }
   }
 
@@ -53,21 +53,21 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
     "use the acquisition costs for a post 31 March 1982 date" in {
       val result = TotalGainRequestConstructor.acquisitionCosts(Some(AcquisitionCostsModel(200)), None, DateModel(1, 4, 1990))
 
-      result shouldBe "&acquisitionCosts=200"
+      result shouldBe "&acquisitionCosts=200.0"
     }
 
     "use the cost of valuation from the 31 March 1982 for a prior date" in {
       val result = TotalGainRequestConstructor.acquisitionCosts(None,
         Some(CostsAtLegislationStartModel("Yes", Some(100))), DateModel(1, 4, 1980))
 
-      result shouldBe "&acquisitionCosts=100"
+      result shouldBe "&acquisitionCosts=100.0"
     }
 
     "return 0 costs for a prior date when not given" in {
       val result = TotalGainRequestConstructor.acquisitionCosts(Some(AcquisitionCostsModel(200)),
         Some(CostsAtLegislationStartModel("No", Some(100))), DateModel(1, 4, 1980))
 
-      result shouldBe "&acquisitionCosts=0"
+      result shouldBe "&acquisitionCosts=0.0"
     }
   }
 
@@ -76,7 +76,7 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
     "produce a valid query string with a provided value" in {
       val result = TotalGainRequestConstructor.improvements(ImprovementsModel("Yes", Some(300), None))
 
-      result shouldBe "&improvements=300"
+      result shouldBe "&improvements=300.0"
     }
 
     "produce a valid query string with no provided value" in {
@@ -97,7 +97,7 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
     "produce a valid query string with a provided value" in {
       val result = TotalGainRequestConstructor.rebasedCosts(RebasedCostsModel("Yes", Some(300)))
 
-      result shouldBe "&rebasedCosts=300"
+      result shouldBe "&rebasedCosts=300.0"
     }
 
     "produce a valid query string with no provided value" in {
@@ -118,7 +118,7 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
     "produce a valid query string with a provided value" in {
       val result = TotalGainRequestConstructor.improvementsAfterTaxStarted(ImprovementsModel("Yes", None, Some(300)))
 
-      result shouldBe "&improvementsAfterTaxStarted=300"
+      result shouldBe "&improvementsAfterTaxStarted=300.0"
     }
 
     "produce a valid query string with no provided value" in {
@@ -160,7 +160,7 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
         ImprovementsModel("Yes", None, Some(30)),
         DateModel(5, 4, 2015))
 
-      result shouldBe "&rebasedValue=3000&rebasedCosts=300&improvementsAfterTaxStarted=30"
+      result shouldBe "&rebasedValue=3000.0&rebasedCosts=300.0&improvementsAfterTaxStarted=30.0"
     }
 
     "produce an empty query string with an acquisition date after tax start" in {
@@ -193,7 +193,7 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
 
       val result = TotalGainRequestConstructor.totalGainQuery(model)
 
-      result shouldBe "disposalValue=1000&disposalCosts=100&acquisitionValue=2000&acquisitionCosts=200&improvements=10" +
+      result shouldBe "disposalValue=1000.0&disposalCosts=100.0&acquisitionValue=2000.0&acquisitionCosts=200.0&improvements=10.0" +
         "&disposalDate=2016-10-5&acquisitionDate=2015-4-6"
     }
 
@@ -215,8 +215,8 @@ class TotalGainRequestConstructorSpec extends CommonPlaySpec {
 
       val result = TotalGainRequestConstructor.totalGainQuery(model)
 
-      result shouldBe "disposalValue=1000&disposalCosts=100&acquisitionValue=2000&acquisitionCosts=200&improvements=10" +
-      "&rebasedValue=3000&rebasedCosts=300&improvementsAfterTaxStarted=20&disposalDate=2016-10-5&acquisitionDate=2013-10-4"
+      result shouldBe "disposalValue=1000.0&disposalCosts=100.0&acquisitionValue=2000.0&acquisitionCosts=200.0&improvements=10.0" +
+      "&rebasedValue=3000.0&rebasedCosts=300.0&improvementsAfterTaxStarted=20.0&disposalDate=2016-10-5&acquisitionDate=2013-10-4"
     }
 
     "calling afterLegislation" should {


### PR DESCRIPTION
BigDecimals that are too big and ended in 0.00 were being displayed with scientific notation, this ensures the forms play back user inputs only with 2 decimals or 0, overriding the automatic sci notation. Also updated the backend calls to turn big decimals to doubles first to avoid the same issue and better conform to backend url parameter types.
