### PR TITLE
[DLS-9353] add new transforms for currency handling

### DIFF
--- a/app/common/Transformers.scala
+++ b/app/common/Transformers.scala
@@ -20,6 +20,17 @@ import scala.util.{Failure, Success, Try}
 
 object Transformers {
 
+  val stripCurrencyCharacters: String => String = (input) =>
+    input
+      .trim()
+      .replaceAll(",", "")
+      .replaceAll("£", "")
+
+  val stripOptionalCurrencyCharacters: Option[String] => Option[String] = (input) => input match {
+    case Some(v) => Some(stripCurrencyCharacters(v))
+    case None => None
+  }
+
   val stringToBigDecimal: String => BigDecimal = (input) => Try(BigDecimal(input.trim)) match {
     case Success(value) => value
     case Failure(_) => BigDecimal(0)

--- a/app/forms/AcquisitionCostsForm.scala
+++ b/app/forms/AcquisitionCostsForm.scala
@@ -28,6 +28,7 @@ object AcquisitionCostsForm {
   val acquisitionCostsForm = Form(
     mapping(
       "acquisitionCosts" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("error.real", mandatoryCheck)
         .verifying("error.real", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/AcquisitionValueForm.scala
+++ b/app/forms/AcquisitionValueForm.scala
@@ -27,6 +27,7 @@ object AcquisitionValueForm {
   val acquisitionValueForm = Form(
     mapping(
       "acquisitionValue" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.acquisitionValue.errorReal", mandatoryCheck)
         .verifying("calc.acquisitionValue.errorReal", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/AnnualExemptAmountForm.scala
+++ b/app/forms/AnnualExemptAmountForm.scala
@@ -27,6 +27,7 @@ object AnnualExemptAmountForm {
   def annualExemptAmountForm(maxAEA: BigDecimal = BigDecimal(0)): Form[AnnualExemptAmountModel] = Form(
     mapping(
       "annualExemptAmount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.annualExemptAmount.errorReal", mandatoryCheck)
         .verifying("calc.annualExemptAmount.errorReal", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/BroughtForwardLossesForm.scala
+++ b/app/forms/BroughtForwardLossesForm.scala
@@ -54,6 +54,7 @@ object BroughtForwardLossesForm {
         .verifying("calc.broughtForwardLosses.errors.required", yesNoCheck)
         .transform(stringToBoolean, booleanToString),
       "broughtForwardLoss" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .transform(stringToOptionalBigDecimal, optionalBigDecimalToString)
     )(BroughtForwardLossesModel.apply)(BroughtForwardLossesModel.unapply)
       .verifying("error.real", verifyMandatory)

--- a/app/forms/CurrentIncomeForm.scala
+++ b/app/forms/CurrentIncomeForm.scala
@@ -27,6 +27,7 @@ object CurrentIncomeForm {
   val currentIncomeForm = Form(
     mapping(
       "currentIncome" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.currentIncome.errorReal", mandatoryCheck)
         .verifying("calc.currentIncome.errorReal", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/DisposalCostsForm.scala
+++ b/app/forms/DisposalCostsForm.scala
@@ -26,6 +26,7 @@ object DisposalCostsForm {
   val disposalCostsForm = Form(
     mapping(
       "disposalCosts" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.disposalCosts.errorReal", mandatoryCheck)
         .verifying("calc.disposalCosts.errorReal", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/DisposalValueForm.scala
+++ b/app/forms/DisposalValueForm.scala
@@ -27,6 +27,7 @@ object DisposalValueForm {
   val disposalValueForm = Form(
     mapping(
       "disposalValue" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.disposalValue.errorReal", mandatoryCheck)
         .verifying("calc.disposalValue.errorReal", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/HowMuchGainForm.scala
+++ b/app/forms/HowMuchGainForm.scala
@@ -27,6 +27,7 @@ object HowMuchGainForm {
   val howMuchGainForm = Form(
     mapping(
       "howMuchGain" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.howMuchGain.errorReal", mandatoryCheck)
         .verifying("calc.howMuchGain.errorReal", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/HowMuchLossForm.scala
+++ b/app/forms/HowMuchLossForm.scala
@@ -27,6 +27,7 @@ object HowMuchLossForm {
   val howMuchLossForm: Form[HowMuchLossModel] = Form(
     mapping(
       "loss" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.howMuchLoss.errorReal", mandatoryCheck)
         .verifying("calc.howMuchLoss.errorReal", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/ImprovementsForm.scala
+++ b/app/forms/ImprovementsForm.scala
@@ -34,6 +34,7 @@ object ImprovementsForm {
           "improvementsAmt" -> mandatoryIf(
             isEqual("isClaimingImprovements", "Yes"),
             common.Formatters.text("calc.improvements.error.no.value.supplied")
+              .transform(stripCurrencyCharacters, stripCurrencyCharacters)
               .verifying("error.number", bigDecimalCheck)
               .transform(stringToBigDecimal, bigDecimalToString)
               .verifying(
@@ -47,6 +48,7 @@ object ImprovementsForm {
           "improvementsAmtAfter" -> mandatoryIf(
             isEqual("isClaimingImprovements", "Yes"),
             common.Formatters.text("calc.improvements.error.no.value.supplied")
+              .transform(stripCurrencyCharacters, stripCurrencyCharacters)
               .verifying("error.number", bigDecimalCheck)
               .transform(stringToBigDecimal, bigDecimalToString)
               .verifying(
@@ -66,6 +68,7 @@ object ImprovementsForm {
           "improvementsAmt" -> mandatoryIf(
             isEqual("isClaimingImprovements", "Yes"),
             common.Formatters.text("calc.improvements.error.no.value.supplied")
+              .transform(stripCurrencyCharacters, stripCurrencyCharacters)
               .verifying("error.number", bigDecimalCheck)
               .transform(stringToBigDecimal, bigDecimalToString)
               .verifying(
@@ -77,6 +80,7 @@ object ImprovementsForm {
               )
           ),
         "improvementsAmtAfter" -> optional(text)
+          .transform(stripOptionalCurrencyCharacters, stripOptionalCurrencyCharacters)
           .transform(optionalStringToOptionalBigDecimal, optionalBigDecimalToOptionalString)
         )(ImprovementsModel.apply)(ImprovementsModel.unapply))
     }

--- a/app/forms/MarketDisposalValueForm.scala
+++ b/app/forms/MarketDisposalValueForm.scala
@@ -31,6 +31,7 @@ trait MarketDisposalValueForm {
   val marketValueForm = Form(
     mapping(
       "disposalValue" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying(errorReal, mandatoryCheck)
         .verifying(errorReal, bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/OtherReliefsForm.scala
+++ b/app/forms/OtherReliefsForm.scala
@@ -28,6 +28,7 @@ object OtherReliefsForm {
     Form(
       mapping(
         "otherReliefs" -> text
+          .transform(stripCurrencyCharacters, stripCurrencyCharacters)
           .verifying("calc.otherReliefs.errorReal", mandatoryCheck)
           .verifying("calc.otherReliefs.errorReal", bigDecimalCheck)
           .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/PersonalAllowanceForm.scala
+++ b/app/forms/PersonalAllowanceForm.scala
@@ -27,6 +27,7 @@ object PersonalAllowanceForm {
   def personalAllowanceForm (maxPA: BigDecimal = BigDecimal(0)): Form[PersonalAllowanceModel] = Form (
     mapping(
       "personalAllowance" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.personalAllowance.errorReal", mandatoryCheck)
         .verifying("calc.personalAllowance.errorReal", bigDecimalCheck)
         .transform(stringToBigDecimal, bigDecimalToString)

--- a/app/forms/RebasedCostsForm.scala
+++ b/app/forms/RebasedCostsForm.scala
@@ -33,6 +33,7 @@ object RebasedCostsForm {
       "rebasedCosts" -> mandatoryIf(
         isEqual("hasRebasedCosts", "Yes"),
         common.Formatters.text("calc.rebasedCosts.error.no.value.supplied")
+          .transform(stripCurrencyCharacters, stripCurrencyCharacters)
           .verifying("error.number", bigDecimalCheck)
           .transform(stringToBigDecimal, bigDecimalToString)
           .verifying(

--- a/app/forms/RebasedValueForm.scala
+++ b/app/forms/RebasedValueForm.scala
@@ -27,6 +27,7 @@ object RebasedValueForm {
   val rebasedValueForm: Form[RebasedValueModel] = Form(
     mapping(
       "rebasedValueAmt" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.nonResident.rebasedValue.error.no.value.supplied", mandatoryCheck)
         .verifying("calc.nonResident.rebasedValue.error.no.value.supplied", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/WorthBeforeLegislationStartForm.scala
+++ b/app/forms/WorthBeforeLegislationStartForm.scala
@@ -27,6 +27,7 @@ object WorthBeforeLegislationStartForm {
   val worthBeforeLegislationStartForm: Form[WorthBeforeLegislationStartModel] = Form(
     mapping(
       "worthBeforeLegislationStart" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.worthBeforeLegislationStart.errorReal", mandatoryCheck)
         .verifying("calc.worthBeforeLegislationStart.errorReal", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -43,8 +43,8 @@ calc.error.summary.heading = This page has errors
 session.timeout.message = Your session has ended
 
 ## PLAY! Error Overrides ##
-error.number = Enter a number without commas, for example 10000.00
-error.real = Enter a number without commas, for example 10000.00
+error.number = Enter a number, for example 10000.00
+error.real = Enter a real number, for example 10000
 
 ## Common date Messages ##
 ## Use common messages if some but not all pages use these messages. ##

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/test/common/TransformersSpec.scala
+++ b/test/common/TransformersSpec.scala
@@ -18,6 +18,24 @@ package common
 
 class TransformersSpec extends CommonPlaySpec {
 
+  "stripCurrencyCharacters" should {
+    "return a cleaned currency amount" when {
+      "the transform is applied to an amount with commas and pound signs" in {
+        val result = Transformers.stripCurrencyCharacters("£1,999")
+        result shouldBe "1999"
+      }
+    }
+  }
+
+  "stripOptionalCurrencyCharacters" should {
+    "return a cleaned currency amount" when {
+      "the transform is applied to an optional amount with commas and pound signs" in {
+        val result = Transformers.stripOptionalCurrencyCharacters(Some("£1,999"))
+        result shouldBe Some("1999")
+      }
+    }
+  }
+
   "stringToBigDecimal" should {
     "return a BigDecimal" when {
       "the transformation fails" in {


### PR DESCRIPTION
# DLS-9353 Forgive commas and pound signs in currency inputs

**New feature**

Accessibility requirements are that we forgive user entry of commas and pound signs in text inputs asking for currency amounts. This pull request introduces a new Transform to strip these characters before validation of the contents begins and uses that transform in the relevant validations.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
