### PR TITLE
Removed double label

### DIFF
--- a/app/views/calculation/otherReliefsFlat.scala.html
+++ b/app/views/calculation/otherReliefsFlat.scala.html
@@ -42,8 +42,6 @@
 
     @form(action = controllers.routes.OtherReliefsFlatController.submitOtherReliefsFlat) {
 
-        <label for="otherReliefs" class="govuk-visually-hidden">@Messages("calc.otherReliefs.question")</label>
-
         <span class="govuk-hint">@Messages("calc.otherReliefs.help")</span>
 
         <div class="govuk-inset-text">

--- a/test/views/OtherReliefsFlatViewSpec.scala
+++ b/test/views/OtherReliefsFlatViewSpec.scala
@@ -27,15 +27,28 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import views.html.calculation.otherReliefsFlat
 
-class OtherReliefsFlatViewSpec extends CommonPlaySpec with WithCommonFakeApplication with MockitoSugar with FakeRequestHelper {
+class OtherReliefsFlatViewSpec
+    extends CommonPlaySpec
+    with WithCommonFakeApplication
+    with MockitoSugar
+    with FakeRequestHelper {
 
   val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
-  implicit lazy val mockMessage = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
-  lazy val otherReliefsFlatView = fakeApplication.injector.instanceOf[otherReliefsFlat]
+  implicit lazy val mockMessage = fakeApplication.injector
+    .instanceOf[MessagesControllerComponents]
+    .messagesApi
+    .preferred(fakeRequest)
+  lazy val otherReliefsFlatView =
+    fakeApplication.injector.instanceOf[otherReliefsFlat]
 
   "The Other Reliefs Flat view" when {
     "not supplied with a pre-existing stored value and a taxable gain" should {
-      lazy val view = otherReliefsFlatView(otherReliefsForm, hasExistingReliefAmount = false, BigDecimal(2000), BigDecimal(2500))(fakeRequest, mockMessage)
+      lazy val view = otherReliefsFlatView(
+        otherReliefsForm,
+        hasExistingReliefAmount = false,
+        BigDecimal(2000),
+        BigDecimal(2500)
+      )(fakeRequest, mockMessage)
       lazy val document = Jsoup.parse(view.body)
 
       "have a back link" which {
@@ -63,7 +76,13 @@ class OtherReliefsFlatViewSpec extends CommonPlaySpec with WithCommonFakeApplica
       }
 
       s"have a home link to '${controllers.routes.DisposalDateController.disposalDate.url}'" in {
-        document.getElementsByClass("hmrc-header__service-name hmrc-header__service-name--linked").attr("href") shouldEqual controllers.routes.DisposalDateController.disposalDate.url
+        document
+          .getElementsByClass(
+            "hmrc-header__service-name hmrc-header__service-name--linked"
+          )
+          .attr(
+            "href"
+          ) shouldEqual controllers.routes.DisposalDateController.disposalDate.url
       }
 
       "have a form" which {
@@ -74,7 +93,9 @@ class OtherReliefsFlatViewSpec extends CommonPlaySpec with WithCommonFakeApplica
         }
 
         s"has an action of '${controllers.routes.OtherReliefsFlatController.otherReliefsFlat.url}'" in {
-          form.attr("action") shouldBe controllers.routes.OtherReliefsFlatController.otherReliefsFlat.url
+          form.attr(
+            "action"
+          ) shouldBe controllers.routes.OtherReliefsFlatController.otherReliefsFlat.url
         }
       }
 
@@ -83,13 +104,12 @@ class OtherReliefsFlatViewSpec extends CommonPlaySpec with WithCommonFakeApplica
         s"has the text '${messages.OtherReliefs.question}'" in {
           label.text shouldBe messages.OtherReliefs.question
         }
-        "has the class 'visuallyhidden'" in {
-          label.attr("class") shouldBe "govuk-visually-hidden"
-        }
       }
 
       s"have the help text '${messages.OtherReliefs.help}'" in {
-        document.body.getElementsByClass("govuk-hint").text() shouldBe messages.OtherReliefs.help
+        document.body
+          .getElementsByClass("govuk-hint")
+          .text() shouldBe messages.OtherReliefs.help
       }
 
       "have additional content" which {
@@ -104,11 +124,15 @@ class OtherReliefsFlatViewSpec extends CommonPlaySpec with WithCommonFakeApplica
         }
 
         "has a list entry with the total gain message and value" in {
-          content.select("li#totalGain").text() shouldBe s"${messages.OtherReliefs.totalGain} £2,500"
+          content
+            .select("li#totalGain")
+            .text() shouldBe s"${messages.OtherReliefs.totalGain} £2,500"
         }
 
         "has a list entry with the taxable gain message and value" in {
-          content.select("li#taxableGain").text() shouldBe s"${messages.OtherReliefs.taxableGain} £2,000"
+          content
+            .select("li#taxableGain")
+            .text() shouldBe s"${messages.OtherReliefs.taxableGain} £2,000"
         }
       }
 
@@ -129,17 +153,36 @@ class OtherReliefsFlatViewSpec extends CommonPlaySpec with WithCommonFakeApplica
       }
 
       "should produce the same output when render and f are called" in {
-        otherReliefsFlatView.f(otherReliefsForm, false, BigDecimal(2000), BigDecimal(2500))(fakeRequest, mockMessage) shouldBe otherReliefsFlatView.render(otherReliefsForm, false, BigDecimal(2000), BigDecimal(2500), fakeRequest, mockMessage)
+        otherReliefsFlatView.f(
+          otherReliefsForm,
+          false,
+          BigDecimal(2000),
+          BigDecimal(2500)
+        )(fakeRequest, mockMessage) shouldBe otherReliefsFlatView.render(
+          otherReliefsForm,
+          false,
+          BigDecimal(2000),
+          BigDecimal(2500),
+          fakeRequest,
+          mockMessage
+        )
       }
     }
 
     "supplied with a pre-existing stored value and a negative taxable gain" should {
       val map = Map("otherReliefs" -> "1000")
-      lazy val view = otherReliefsFlatView(otherReliefsForm.bind(map), hasExistingReliefAmount = true, BigDecimal(-1000), BigDecimal(2000))(fakeRequest, mockMessage)
+      lazy val view = otherReliefsFlatView(
+        otherReliefsForm.bind(map),
+        hasExistingReliefAmount = true,
+        BigDecimal(-1000),
+        BigDecimal(2000)
+      )(fakeRequest, mockMessage)
       lazy val document = Jsoup.parse(view.body)
 
       "has a list entry with the loss carried forward message and value" in {
-        document.select("li#taxableGain").text() shouldBe s"${messages.OtherReliefs.lossCarriedForward} £1,000"
+        document
+          .select("li#taxableGain")
+          .text() shouldBe s"${messages.OtherReliefs.lossCarriedForward} £1,000"
       }
 
       "have a button" which {
@@ -160,9 +203,15 @@ class OtherReliefsFlatViewSpec extends CommonPlaySpec with WithCommonFakeApplica
     }
 
     "supplied with an invalid map" should {
-      val model = CalculationResultModel(100, 1000, -100, 18, 0, None, None, None)
+      val model =
+        CalculationResultModel(100, 1000, -100, 18, 0, None, None, None)
       val map = Map("otherReliefs" -> "-1000")
-      lazy val view = otherReliefsFlatView(otherReliefsForm.bind(map), hasExistingReliefAmount = true, BigDecimal(2000), BigDecimal(2000))(fakeRequest, mockMessage)
+      lazy val view = otherReliefsFlatView(
+        otherReliefsForm.bind(map),
+        hasExistingReliefAmount = true,
+        BigDecimal(2000),
+        BigDecimal(2000)
+      )(fakeRequest, mockMessage)
       lazy val document = Jsoup.parse(view.body)
 
       "have an error summary" in {


### PR DESCRIPTION
# [DLS-9691](https://jira.tools.tax.service.gov.uk/browse/DLS-9691) Multiple labels / duplicated content [WCAG]

**Bug fix** 
One version of the "other reliefs" page has two labels assigned for the currency input.

This causes the question to be repeated when the user lands on the input.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
