### PR TITLE
[DLS-10028] restore the recoverToStart use on summary view

### DIFF
--- a/app/controllers/SummaryController.scala
+++ b/app/controllers/SummaryController.scala
@@ -144,7 +144,7 @@ class SummaryController @Inject()(calcConnector: CalculatorConnector,
             questionsForPrint = questionAnswerRows
           ))
       }
-    })
+    }).recoverToStart
   }
 
   private[controllers] def setURPanelFlag(implicit hc: HeaderCarrier): Boolean = {


### PR DESCRIPTION
# DLS-10028

**Bug fix** (delete as appropriate)

There was a recoverToStart call on the summary view which avoided exposing users (and logs) to errors when they navigate to the page without having completed the journey, this was taken off to increase visibility of errors when developing and should have been restored before opening the last pull request.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
