### PR TITLE
DLS-10051: Play 3.0 migration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ lazy val appName = "cgt-calculator-non-resident-frontend"
 lazy val appDependencies : Seq[ModuleID] = Seq.empty
 lazy val plugins : Seq[Plugins] = Seq(play.sbt.PlayScala)
 lazy val playSettings : Seq[Setting[_]] = Seq.empty
-val silencerVersion = "1.17.13"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(Seq(play.sbt.PlayScala, SbtDistributablesPlugin) ++ plugins : _*)

--- a/build.sbt
+++ b/build.sbt
@@ -32,16 +32,11 @@ lazy val microservice = Project(appName, file("."))
   .settings(scalaSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.12",
     libraryDependencies ++= AppDependencies(),
     retrieveManaged := true,
     //evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
-    Assets / pipelineStages := Seq(digest),
-    scalacOptions += "-P:silencer:pathFilters=views;routes",
-    libraryDependencies ++= Seq(
-      compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
-      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
-    ),
+    Assets / pipelineStages := Seq(digest)
   )
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,3 @@
 # Add all the application routes to the app.routes file
 ->         /calculate-your-capital-gains/non-resident/           app.Routes
 ->         /                                                     health.Routes
-
-GET        /admin/metrics                           @com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-import play.core.PlayVersion
 import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion         = "7.22.0"
-  val playVersion              = "play-28"
-  val hmrcMongoVersion         = "1.3.0"
+  val bootstrapVersion         = "8.5.0"
+  val playVersion              = "play-30"
+  val hmrcMongoVersion         = "1.7.0"
 
   val compile = Seq(
-    "uk.gov.hmrc"       %% s"bootstrap-frontend-$playVersion"    % bootstrapVersion,
-    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion"    % "8.5.0",
-    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"            % hmrcMongoVersion,
-    "uk.gov.hmrc"       %% "play-conditional-form-mapping"       % s"1.13.0-$playVersion",
-    "org.julienrf"      %% "play-json-derived-codecs"            % "10.1.0"
+    "uk.gov.hmrc"       %% s"bootstrap-frontend-$playVersion"             % bootstrapVersion,
+    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion"             % bootstrapVersion,
+    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"                     % hmrcMongoVersion,
+    "uk.gov.hmrc"       %% s"play-conditional-form-mapping-$playVersion"  % "2.0.0",
+    "org.julienrf"      %% "play-json-derived-codecs"                     % "10.1.0"
   )
 
   trait TestDependencies {
@@ -40,13 +39,13 @@ object AppDependencies {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test = Seq(
         "uk.gov.hmrc"             %% s"bootstrap-test-$playVersion"   % bootstrapVersion    % scope,
-        "org.scalatestplus.play"  %% "scalatestplus-play"             % "5.1.0"             % scope,
+        "org.scalatestplus.play"  %% "scalatestplus-play"             % "7.0.1"             % scope,
         "org.scalatestplus"       %% "scalatestplus-mockito"          % "1.0.0-M2"          % scope,
-        "org.mockito"             %  "mockito-core"                   % "5.5.0"            % scope,
+        "org.mockito"             %  "mockito-core"                   % "5.11.0"            % scope,
         "org.pegdown"             %  "pegdown"                        % "1.6.0"             % scope,
-        "org.jsoup"               %  "jsoup"                          % "1.16.1"            % scope,
-        "com.typesafe.play"       %% "play-test"                      % PlayVersion.current % scope,
-        "uk.gov.hmrc.mongo"       %%  s"hmrc-mongo-test-$playVersion" % hmrcMongoVersion      % scope
+        "org.jsoup"               %  "jsoup"                          % "1.17.2"            % scope,
+        "org.playframework"       %% "play-test"                      % "3.0.2"             % scope,
+        "uk.gov.hmrc.mongo"       %%  s"hmrc-mongo-test-$playVersion" % hmrcMongoVersion    % scope
       )
     }.test
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,3 @@ addSbtPlugin("org.playframework"    %% "sbt-plugin"             % "3.0.2")
 addSbtPlugin("org.scoverage"        %  "sbt-scoverage"          % "2.0.11")
 addSbtPlugin("org.scalastyle"       %% "scalastyle-sbt-plugin"  % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("com.github.sbt"       %  "sbt-digest"             % "2.0.0")
-
-resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,16 +1,11 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc"          %  "sbt-auto-build"         % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"          %  "sbt-distributables"     % "2.5.0")
+addSbtPlugin("org.playframework"    %% "sbt-plugin"             % "3.0.2")
+addSbtPlugin("org.scoverage"        %  "sbt-scoverage"          % "2.0.11")
+addSbtPlugin("org.scalastyle"       %% "scalastyle-sbt-plugin"  % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
+addSbtPlugin("com.github.sbt"       %  "sbt-digest"             % "2.0.0")
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
-
-addSbtPlugin("com.typesafe.play" %% "sbt-plugin" % "2.8.20")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
-
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")

--- a/test/common/CommonPlaySpec.scala
+++ b/test/common/CommonPlaySpec.scala
@@ -16,8 +16,8 @@
 
 package common
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike

--- a/test/constructors/AnswersConstructorSpec.scala
+++ b/test/constructors/AnswersConstructorSpec.scala
@@ -16,7 +16,7 @@
 
 package constructors
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import connectors.CalculatorConnector

--- a/test/controllers/CalculationControllerTests/AcquisitionCostsActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/AcquisitionCostsActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{AcquisitionCosts => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}

--- a/test/controllers/CalculationControllerTests/AcquisitionDateActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/AcquisitionDateActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{AcquisitionDate => messages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import config.ApplicationConfig

--- a/test/controllers/CalculationControllerTests/AcquisitionValueActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/AcquisitionValueActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{AcquisitionValue => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/AnnualExemptAmountActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/AnnualExemptAmountActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{AnnualExemptAmount => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/BoughtForLessActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/BoughtForLessActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.{NonResident => messages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import config.ApplicationConfig

--- a/test/controllers/CalculationControllerTests/BroughtForwardLossesActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/BroughtForwardLossesActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.{NonResident => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/CalculationElectionActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/CalculationElectionActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{CalculationElection => messages, CalculationElectionNoReliefs => nRMessages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}

--- a/test/controllers/CalculationControllerTests/CheckYourAnswersActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/CheckYourAnswersActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{CheckYourAnswers => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/ClaimingReliefsActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/ClaimingReliefsActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{ClaimingReliefs => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.NonResidentKeys

--- a/test/controllers/CalculationControllerTests/CostsAtLegislationStartActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/CostsAtLegislationStartActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{CostsAtLegislationStart => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/CurrentIncomeActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/CurrentIncomeActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{CurrentIncome => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/DisposalCostsActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/DisposalCostsActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{DisposalCosts => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}

--- a/test/controllers/CalculationControllerTests/DisposalDateActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/DisposalDateActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{DisposalDate => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/DisposalValueActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/DisposalValueActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{DisposalValue => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/HowBecameOwnerActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/HowBecameOwnerActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{HowBecameOwner => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/HowMuchGainActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/HowMuchGainActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{HowMuchGain => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/HowMuchLossActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/HowMuchLossActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.{NonResident => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/ImprovementsActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/ImprovementsActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/ImprovementsRebasedActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/ImprovementsRebasedActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/IsClaimingImprovementsActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/IsClaimingImprovementsActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/MarketValueWhenSoldOrGaveAwayActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/MarketValueWhenSoldOrGaveAwayActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{MarketValue => marketValueMessages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/NoCapitalGainsTaxActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/NoCapitalGainsTaxActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{NoCapitalGainsTax => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/OtherPropertiesActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/OtherPropertiesActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{OtherProperties => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import com.codahale.metrics.SharedMetricRegistries

--- a/test/controllers/CalculationControllerTests/OtherReliefsActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/OtherReliefsActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{OtherReliefs => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, TestModels, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/OtherReliefsFlatActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/OtherReliefsFlatActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{OtherReliefs => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, TestModels, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/OtherReliefsRebasedActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/OtherReliefsRebasedActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{OtherReliefs => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, TestModels, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/OtherReliefsTAActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/OtherReliefsTAActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{OtherReliefs => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, TestModels, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/OutsideTaxYearActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/OutsideTaxYearActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.{NonResident => commonMessages, OutsideTaxYears => messages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import config.ApplicationConfig

--- a/test/controllers/CalculationControllerTests/PersonalAllowanceActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/PersonalAllowanceActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{PersonalAllowance => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}

--- a/test/controllers/CalculationControllerTests/PreviousGainOrLossActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/PreviousGainOrLossActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{PreviousLossOrGain => messages}
 import common.KeystoreKeys.{NonResidentKeys => keystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/PrivateResidenceReliefActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/PrivateResidenceReliefActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{PrivateResidenceRelief => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/PropertyLivedInActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/PropertyLivedInActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.{PropertyLivedIn => messages}
 import common.KeystoreKeys.{NonResidentKeys => keyStoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/RebasedCostsActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/RebasedCostsActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{RebasedCosts => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/RebasedValueActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/RebasedValueActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{RebasedValue => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/SoldForLessActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/SoldForLessActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{SoldForLess => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => keyStoreKeys}

--- a/test/controllers/CalculationControllerTests/SoldOrGivenAwayActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/SoldOrGivenAwayActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{SoldOrGivenAway => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}

--- a/test/controllers/CalculationControllerTests/SummaryActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/SummaryActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{Summary => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.nonresident.Flat

--- a/test/controllers/CalculationControllerTests/WhatNextControllerSpec.scala
+++ b/test/controllers/CalculationControllerTests/WhatNextControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import config.ApplicationConfig

--- a/test/controllers/CalculationControllerTests/WhoDidYouGiveItToControllerSpec.scala
+++ b/test/controllers/CalculationControllerTests/WhoDidYouGiveItToControllerSpec.scala
@@ -16,8 +16,8 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
-import akka.util.Timeout
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.Timeout
 import assets.MessageLookup
 import assets.MessageLookup.{NoTaxToPay => messages}
 import common.KeystoreKeys.{NonResidentKeys => keystoreKeys}

--- a/test/controllers/CalculationControllerTests/WorthBeforeLegislationStartActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/WorthBeforeLegislationStartActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{WorthBeforeLegislationStart => messages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import config.ApplicationConfig

--- a/test/controllers/CalculationControllerTests/WorthWhenBoughtForLessActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/WorthWhenBoughtForLessActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{WorthWhenBoughtForLess => messages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}
 import common.{CommonPlaySpec, WithCommonFakeApplication}

--- a/test/controllers/CalculationControllerTests/WorthWhenGiftedToActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/WorthWhenGiftedToActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{WorthWhenGiftedTo => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}

--- a/test/controllers/CalculationControllerTests/WorthWhenInheritedActionSpec.scala
+++ b/test/controllers/CalculationControllerTests/WorthWhenInheritedActionSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.CalculationControllerTests
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import assets.MessageLookup.NonResident.{WorthWhenInherited => messages}
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.KeystoreKeys.{NonResidentKeys => KeystoreKeys}

--- a/test/controllers/TimeoutControllerSpec.scala
+++ b/test/controllers/TimeoutControllerSpec.scala
@@ -16,8 +16,8 @@
 
 package controllers
 
-import akka.stream.Materializer
-import akka.util.Timeout
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.Timeout
 import assets.MessageLookup.{NonResident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import config.ApplicationConfig

--- a/test/routes/RoutesSpec.scala
+++ b/test/routes/RoutesSpec.scala
@@ -17,7 +17,7 @@
 package routes
 
 import common.{CommonPlaySpec, WithCommonFakeApplication}
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 
 class RoutesSpec extends CommonPlaySpec with WithCommonFakeApplication with Matchers {
 


### PR DESCRIPTION
DLS-10051: Upgrade cgt-calculator-non-resident-frontend to Play 3.0

Repo upgraded to Play 3.0 and other plugins/dependencies updated to the latest versions. Akka has been migrated to Pekko.

## Checklist
 - [X]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [N/A]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [X]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [X]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [X]  I've run a dependency check to ensure all dependencies are up to date
