### PR TITLE
DLS-10489 Replace PRR upper bound message with a generic one

### DIFF
--- a/app/forms/PrivateResidenceReliefForm.scala
+++ b/app/forms/PrivateResidenceReliefForm.scala
@@ -38,7 +38,7 @@ object PrivateResidenceReliefForm {
       .transform(stringToBigDecimal, bigDecimalToString)
       .verifying("calc.privateResidenceReliefValue.error.errorNegative", isPositive)
       .verifying("calc.privateResidenceReliefValue.error.errorDecimalPlaces", decimalPlacesCheck)
-      .verifying(maxMonetaryValueConstraint(errMsgKey = "calc.privateResidenceRelief.error.maxNumericExceeded"))
+      .verifying(maxMonetaryValueConstraint())
   )
 
   def isClaimingPrrForm: Form[ClaimingPrrModel] =

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -343,7 +343,6 @@ calc.previousLossOrGain.question = A wnaeth y gwarediadau hyn arwain at golledio
 
 ## Private Residence Relief ##
 calc.privateResidenceRelief.errors.required = Dewiswch ''Iawn'' os ydych yn hawlio Rhyddhad Preswylfa Breifat
-calc.privateResidenceRelief.error.maxNumericExceeded = Nodwch rif ar gyfer sawl diwrnod rydych yn gwneud cais ar eu cyfer sy’n {0} neu lai
 calc.privateResidenceRelief.helpLink = Ryddhad Preswylfan Preifat ar gyfer y rhai nad ydynt yn breswyl yn y DU
 calc.privateResidenceRelief.helpText = Rhagor o fanylion am
 calc.privateResidenceRelief.intro1 = Gallech gael rhyddhad treth llawn am 365 diwrnod ar gyfer unrhyw flwyddyn dreth pan wnaethoch chi neu’ch priod neu bartner sifil dreulio o leiaf 90 diwrnod yn eich cartref yn y DU.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -309,7 +309,6 @@ calc.privateResidenceRelief.helpLink = Private Residence Relief for non-UK resid
 calc.privateResidenceRelief.intro1 = You could get full tax relief of 365 days for any tax years when you or your spouse or civil partner spent at least 90 days in your UK home.
 calc.privateResidenceRelief.qualify = To qualify, you must nominate the home you are selling as your only or main home to HMRC.
 calc.privateResidenceRelief.errors.required = Select yes if you are claiming Private Residence Relief
-calc.privateResidenceRelief.error.maxNumericExceeded = Enter a value for your days claimed that''s {0} or less
 
 ## Private Residence Relief Value ##
 calc.privateResidenceReliefValue.title = How much Private Residence Relief are you entitled to?

--- a/test/forms/PrivateResidenceReliefFormSpec.scala
+++ b/test/forms/PrivateResidenceReliefFormSpec.scala
@@ -155,7 +155,7 @@ class PrivateResidenceReliefFormSpec extends CommonPlaySpec with WithCommonFakeA
         }
 
         s"return the correct error message" in {
-          form.error("prrClaimed").get.message shouldBe "calc.privateResidenceRelief.error.maxNumericExceeded"
+          form.error("prrClaimed").get.message shouldBe "calc.common.error.maxNumericExceeded"
           form.error("prrClaimed").get.args shouldBe Array("1,000,000,000")
         }
       }


### PR DESCRIPTION
The upper bound is here because all monetary values have an upper bound in this service. This replaces the "how many days" message with a generic one like this:
![image](https://github.com/user-attachments/assets/422d1f58-007d-4b9a-b773-0c353933ca2c)
